### PR TITLE
PHP 8.1 Support

### DIFF
--- a/Block/Product/Reviewwidget.php
+++ b/Block/Product/Reviewwidget.php
@@ -108,6 +108,9 @@ class Reviewwidget extends Framework\View\Element\Template
     protected function getWidgetColor()
     {
         $colour = $this->configHelper->getProductWidgetColour($this->store->getId());
+        if (is_null($colour)) {
+            return;
+        }
         // people will sometimes put hash and sometimes they will forgot so we need to check for this error
         if (strpos($colour, '#') === false) {
             $colour = '#' . $colour;


### PR DESCRIPTION
strpos/preg_match can no longer be called on null e.g. if $colour is not set in admin.

Could well be more instances of this type of error but this was the only one stopping reviews from appearing on product detail pages for us since updating to PHP 8.1