### PR TITLE
add isset before strpos in colour code check

### DIFF
--- a/Block/Product/Reviewwidget.php
+++ b/Block/Product/Reviewwidget.php
@@ -109,7 +109,7 @@ class Reviewwidget extends Framework\View\Element\Template
     {
         $colour = $this->configHelper->getProductWidgetColour($this->store->getId());
         // people will sometimes put hash and sometimes they will forgot so we need to check for this error
-        if (strpos($colour, '#') === false) {
+        if (isset($colour) && strpos($colour, '#') === false) {
             $colour = '#' . $colour;
         }
         // checking to see if we hare a valid colour. If not then we change it to reviews default hex colour


### PR DESCRIPTION
Passing `null` as the first argument of `strpos` is deprecated in php 8.1

This only happens when the product review widget star colour isn't set in the config.