### PR TITLE
add:complete status as trigger in automations magento

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -24,6 +24,7 @@ class Config extends Framework\App\Helper\AbstractHelper
     const XML_CONFIG_MERCHANT_RICH_SNIPPETS_ENABLED = 'reviewscouk_reviews_onpage/richsnippets/merchant_enabled';
     const XML_CONFIG_PRODUCT_RICH_SNIPPETS_ENABLED = 'reviewscouk_reviews_onpage/richsnippets/product_enabled';
     const XML_CONFIG_PRODUCT_REVIEWS_ENABLED = 'reviewscouk_reviews_automation/collection/product_enabled';
+    const XML_CONFIG_INVITATION_TRIGGER = 'reviewscouk_reviews_automation/collection/invitation_trigger';
     const XML_CONFIG_PRODUCT_FEED_ENABLED = 'reviewscouk_reviews_automation/product_feed/product_feed_enabled';
     const XML_CONFIG_USE_GROUP_SKU = "reviewscouk_reviews_advanced/settings/used_grouped_skus";
 
@@ -119,6 +120,13 @@ class Config extends Framework\App\Helper\AbstractHelper
     public function isAISummaryEnabled($magentoStore)
     {
         return $this->getValue(self::XML_CONFIG_INCLUDE_AI_SUMMARY, $magentoStore);
+    }
+
+    public function getInvitationTrigger($magentoStore)
+    {
+        $value = $this->getValue(self::XML_CONFIG_INVITATION_TRIGGER, $magentoStore);
+        // Default to 'shipped' if not set
+        return $value ?: 'shipped';
     }
 
     /**

--- a/Model/Config/Source/InvitationTrigger.php
+++ b/Model/Config/Source/InvitationTrigger.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Reviewscouk\Reviews\Model\Config\Source;
+
+class InvitationTrigger implements \Magento\Framework\Option\ArrayInterface
+{
+    const TRIGGER_SHIPPED = 'shipped';
+    const TRIGGER_COMPLETED = 'completed';
+
+    /**
+     * Options getter
+     *
+     * @return array
+     */
+    public function toOptionArray()
+    {
+        return [
+            ['value' => self::TRIGGER_SHIPPED, 'label' => __('Shipped (when shipment is created)')],
+            ['value' => self::TRIGGER_COMPLETED, 'label' => __('Completed (when order state is complete)')]
+        ];
+    }
+
+    /**
+     * Get options in "key-value" format
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return [
+            self::TRIGGER_SHIPPED => __('Shipped (when shipment is created)'),
+            self::TRIGGER_COMPLETED => __('Completed (when order state is complete)')
+        ];
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -62,6 +62,12 @@
                     <label>Queue Invites:</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
+                <field id="invitation_trigger" translate="label" type="select" sortOrder="15" showInDefault="1"
+                       showInWebsite="1" showInStore="1">
+                    <label>Invitation Trigger:</label>
+                    <source_model>Reviewscouk\Reviews\Model\Config\Source\InvitationTrigger</source_model>
+                    <comment>Choose when to send review invitations. Default: Shipped</comment>
+                </field>
             </group>
             <group id="product_feed" translate="label" type="text" sortOrder="15" showInDefault="1" showInWebsite="1"
                    showInStore="1">

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -4,6 +4,9 @@
     <event name="sales_order_shipment_save_after">
         <observer name="reviewscouk_reviews" instance="Reviewscouk\Reviews\Observer\SendOrderDetails"/>
     </event>
+    <event name="sales_order_save_after">
+        <observer name="reviewscouk_reviews_order_save" instance="Reviewscouk\Reviews\Observer\SendOrderDetails"/>
+    </event>
     <event name="admin_system_config_changed_section_reviewscouk_reviews_automation">
         <observer name="reviewscouk_reviews" instance="Reviewscouk\Reviews\Observer\UpdateProductFeed"/>
     </event>


### PR DESCRIPTION
added a new complete status as trigger in automations for the invites to be queued with selected as completed in the configuration 