### PR TITLE
[REVIEWS-3402] Resolve Legacy Malformed `/invitation` request.

### DIFF
--- a/Observer/SendOrderDetails.php
+++ b/Observer/SendOrderDetails.php
@@ -100,7 +100,7 @@ class SendOrderDetails implements Framework\Event\ObserverInterface
                     $name = $order->getBillingAddress()->getFirstName();
                 }
 
-                $productResponse = $this->apiModel->apiPost('/invitation', [
+                $productResponse = $this->apiModel->apiPost('invitation', [
                     'source'       => 'magento',
                     'name'         => $name,
                     'email'        => $order->getCustomerEmail(),

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ You'll need to sign up at [Reviews.co.uk](https://www.reviews.co.uk "Reviews.co.
 
 | Magento Version | Php Version | REVIEWS.io Plugin Version  |
 |-----------------|-------------|----------------------------|
-| >= 2.4.6        | 8.1, 8.2    | reviewscouk/reviews:0.0.69 |
-| >= 2.4.4        | 8.1         | reviewscouk/reviews:0.0.69 |
-| <= 2.4.3        | <= 7.4      | reviewscouk/reviews:0.0.69 |
+| >= 2.4.6        | 8.1, 8.2    | reviewscouk/reviews:0.0.70 |
+| >= 2.4.4        | 8.1         | reviewscouk/reviews:0.0.70 |
+| <= 2.4.3        | <= 7.4      | reviewscouk/reviews:0.0.70 |
 
 # Installation
 
@@ -18,7 +18,7 @@ You'll need to sign up at [Reviews.co.uk](https://www.reviews.co.uk "Reviews.co.
 2. As this plugin is hosted on [packagist.org](http://packagist.org), you simply use the following to instruct composer to fetch and install the module:
 
     ```bash
-    composer require reviewscouk/reviews:0.0.69
+    composer require reviewscouk/reviews:0.0.70
     ```
 
 3. When this is complete, `cd` to `/bin` and run the following:


### PR DESCRIPTION
The method being used, `apiPost`, already appends a `/` character before the given `$url` function parameter. This has been sending `//invitation` to our API.