### PR TITLE
Add product description handling in feed generation

### DIFF
--- a/Controller/Index/Feed.php
+++ b/Controller/Index/Feed.php
@@ -170,6 +170,18 @@ class Feed implements HttpGetActionInterface
                 $price = $product->getPrice();
                 $finalPrice = $product->getFinalPrice();
 
+                $description = $product->getDescription();
+                if (!is_string($description)) {
+                    $description = '';
+                }
+
+                if ($description === '') {
+                    $shortDescription = $product->getShortDescription();
+                    if (is_string($shortDescription)) {
+                        $description = $shortDescription;
+                    }
+                }
+
                 $productFeed .= "<item>
                         <g:id><![CDATA[" . $product->getSku() . "]]></g:id>
                         <magento_product_id><![CDATA[" . $product->getId() . "]]></magento_product_id>
@@ -177,7 +189,7 @@ class Feed implements HttpGetActionInterface
                         <link><![CDATA[" . $productUrl . "]]></link>
                         <g:price>" . (!empty($price) ? number_format($price, 2) . " " . $store->getCurrentCurrency()->getCode() : '') . "</g:price>
                         <g:sale_price>" . (!empty($finalPrice) ? number_format($finalPrice, 2) . " " . $store->getCurrentCurrency()->getCode() : '') . "</g:sale_price>
-                        <description><![CDATA[]]></description>
+                        <description><![CDATA[" . $description . "]]></description>
                         <g:condition>new</g:condition>
                         <g:image_link><![CDATA[" . $imageLink . "]]></g:image_link>
                         <g:brand><![CDATA[" . $brand . "]]></g:brand>

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ You'll need to sign up at [Reviews.co.uk](https://www.reviews.co.uk "Reviews.co.
 
 | Magento Version | Php Version | REVIEWS.io Plugin Version  |
 |-----------------|-------------|----------------------------|
-| >= 2.4.6        | 8.1, 8.2    | reviewscouk/reviews:0.0.70 |
-| >= 2.4.4        | 8.1         | reviewscouk/reviews:0.0.70 |
-| <= 2.4.3        | <= 7.4      | reviewscouk/reviews:0.0.70 |
+| >= 2.4.6        | 8.1, 8.2    | reviewscouk/reviews:0.0.71 |
+| >= 2.4.4        | 8.1         | reviewscouk/reviews:0.0.71 |
+| <= 2.4.3        | <= 7.4      | reviewscouk/reviews:0.0.71 |
 
 # Installation
 
@@ -18,7 +18,7 @@ You'll need to sign up at [Reviews.co.uk](https://www.reviews.co.uk "Reviews.co.
 2. As this plugin is hosted on [packagist.org](http://packagist.org), you simply use the following to instruct composer to fetch and install the module:
 
     ```bash
-    composer require reviewscouk/reviews:0.0.70
+    composer require reviewscouk/reviews:0.0.71
     ```
 
 3. When this is complete, `cd` to `/bin` and run the following:


### PR DESCRIPTION
Add product description handling in feed generation

Error: `InvalidArgumentException
Argument 'value' must be type of string, NULL given./var/www/html/vendor/magento/framework/Filter/Template.php in Magento\Framework\Filter\Template::filter at line 197
/var/www/html/vendor/reviewscouk/reviews/Controller/Index/Feed.php in Reviewscouk\Reviews\Controller\Index\Feed::execute at line 176`