### PR TITLE
Fix store resolution on multi-store headless Adobe Commerce setups (REVIEWS-4382)

### DIFF
--- a/Model/Api.php
+++ b/Model/Api.php
@@ -11,7 +11,7 @@ class Api extends Framework\Model\AbstractModel
 
     private $configHelper;
     private $messageInterface;
-    private $store;
+    private $storeManager;
 
     public function __construct(
         Reviews\Helper\Config $config,
@@ -21,14 +21,13 @@ class Api extends Framework\Model\AbstractModel
 
         $this->configHelper = $config;
         $this->messageInterface = $managerInterface;
-
-        $this->store = $storeManagerInterface->getStore();
+        $this->storeManager = $storeManagerInterface;
     }
 
     public function apiPost($url, $data, $magento_store_id = null)
     {
         if ($magento_store_id == null) {
-            $magento_store_id = $this->store->getId();
+            $magento_store_id = $this->storeManager->getStore()->getId();
         }
 
         $api_url = 'https://' . $this->getApiDomain($magento_store_id) . '/' . $url;

--- a/Observer/UpdateProductFeed.php
+++ b/Observer/UpdateProductFeed.php
@@ -22,13 +22,17 @@ class UpdateProductFeed implements Framework\Event\ObserverInterface
 
     public function execute(Framework\Event\Observer $observer)
     {
-        // Get current website scope
-        $scopeId = $observer->getEvent()->getWebsite() ?? null;
+        // Resolve a concrete store view from the config-save scope before
+        // touching getStore()/getBaseUrl(), so headless/multi-store installs
+        // (admin host not a registered store view) don't blow up.
+        $store = $this->resolveStore($observer->getEvent());
+        $scopeId = $store->getId();
+        $baseUrl = $store->getBaseUrl();
 
         $setFeed = $this->apiModel->apiPost(
             'integration/set-feed',
             [
-                'url' => $this->storeModel->getStore($scopeId)->getBaseUrl() . 'reviews/index/feed',
+                'url' => $baseUrl . 'reviews/index/feed',
                 'format' => 'xml'
             ],
             $scopeId
@@ -39,11 +43,39 @@ class UpdateProductFeed implements Framework\Event\ObserverInterface
             'integration/app-installed',
             [
                 'platform' => 'magento',
-                'url' => $this->storeModel->getStore($scopeId)->getBaseUrl()
+                'url' => $baseUrl
             ],
             $scopeId
         );
         $this->apiModel->addStatusMessage($appInstalled, "Communication");
 
+    }
+
+    /**
+     * Resolve a concrete store view from the config-save event scope.
+     *
+     * The admin_system_config_changed_section_* event carries 'store' and
+     * 'website' scope identifiers, not a store getStore() can always resolve.
+     * A store-scope save sets 'store'; a website-scope save sets 'website';
+     * a default/global save sets neither. Turn whichever we get into a real
+     * store view (falling back to the default store view) so callers get a
+     * store that resolves without a NoSuchEntityException.
+     *
+     * @param Framework\Event $event
+     * @return \Magento\Store\Api\Data\StoreInterface
+     */
+    protected function resolveStore(Framework\Event $event)
+    {
+        $storeParam = $event->getStore();
+        if ($storeParam) {
+            return $this->storeModel->getStore($storeParam);
+        }
+
+        $websiteParam = $event->getWebsite();
+        if ($websiteParam) {
+            return $this->storeModel->getWebsite($websiteParam)->getDefaultStore();
+        }
+
+        return $this->storeModel->getDefaultStoreView();
     }
 }

--- a/Observer/UpdateProductFeed.php
+++ b/Observer/UpdateProductFeed.php
@@ -28,7 +28,7 @@ class UpdateProductFeed implements Framework\Event\ObserverInterface
         $setFeed = $this->apiModel->apiPost(
             'integration/set-feed',
             [
-                'url' => $this->storeModel->getStore()->getBaseUrl() . 'reviews/index/feed',
+                'url' => $this->storeModel->getStore($scopeId)->getBaseUrl() . 'reviews/index/feed',
                 'format' => 'xml'
             ],
             $scopeId
@@ -39,7 +39,7 @@ class UpdateProductFeed implements Framework\Event\ObserverInterface
             'integration/app-installed',
             [
                 'platform' => 'magento',
-                'url' => isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : ''
+                'url' => $this->storeModel->getStore($scopeId)->getBaseUrl()
             ],
             $scopeId
         );

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ You'll need to sign up at [Reviews.co.uk](https://www.reviews.co.uk "Reviews.co.
 
 | Magento Version | Php Version | REVIEWS.io Plugin Version  |
 |-----------------|-------------|----------------------------|
-| >= 2.4.6        | 8.1, 8.2    | reviewscouk/reviews:0.0.73 |
-| >= 2.4.4        | 8.1         | reviewscouk/reviews:0.0.73 |
-| <= 2.4.3        | <= 7.4      | reviewscouk/reviews:0.0.73 |
+| >= 2.4.6        | 8.1, 8.2    | reviewscouk/reviews:0.0.74 |
+| >= 2.4.4        | 8.1         | reviewscouk/reviews:0.0.74 |
+| <= 2.4.3        | <= 7.4      | reviewscouk/reviews:0.0.74 |
 
 # Installation
 
@@ -18,7 +18,7 @@ You'll need to sign up at [Reviews.co.uk](https://www.reviews.co.uk "Reviews.co.
 2. As this plugin is hosted on [packagist.org](http://packagist.org), you simply use the following to instruct composer to fetch and install the module:
 
     ```bash
-    composer require reviewscouk/reviews:0.0.73
+    composer require reviewscouk/reviews:0.0.74
     ```
 
 3. When this is complete, `cd` to `/bin` and run the following:


### PR DESCRIPTION
## Summary

- Pass `$scopeId` to `getStore($scopeId)` in `UpdateProductFeed::execute()` so URL resolution uses config scope rather than the admin HTTP hostname
- Replace `$_SERVER['HTTP_HOST']` with `$this->storeModel->getStore($scopeId)->getBaseUrl()` so `integration/app-installed` receives the correct storefront URL, not the admin backend hostname
- Defer `getStore()` in `Api` constructor — store `StoreManagerInterface` instead of eagerly calling `getStore()` at DI injection time, which threw when no store view matched the admin URL

## Root cause

On single-instance multi-tenant Adobe Commerce setups, the admin backend URL (`mcprod.smokemart.com.au`) is not registered as a store view. Magento's `StoreManager::getStore()` with no argument tries to resolve the current store from the HTTP hostname — finding no match, it throws *"The store that was requested wasn't found."*

The `$scopeId` was already read from the event on line 26 of `UpdateProductFeed.php` but never passed to `getStore()`.

## Test plan

- [ ] Save REVIEWS.io config on a standard single-store Magento setup — no regression
- [ ] Save config on a multi-store setup where admin URL differs from any store view — no exception, correct storefront URL sent to `integration/app-installed`
- [ ] Verify product feed URL uses storefront base URL, not admin hostname

Fixes [REVIEWS-4382](https://clearerio.atlassian.net/browse/REVIEWS-4382)

🤖 Generated with [Claude Code](https://claude.com/claude-code)