### PR TITLE
[REVIEWS-4263] Use Group SKUs not getting parent SKU in Magento plugin

### DIFF
--- a/Observer/SendOrderDetails.php
+++ b/Observer/SendOrderDetails.php
@@ -6,6 +6,7 @@ use Magento\Framework as Framework;
 use Reviewscouk\Reviews as Reviews;
 use Magento\Catalog as Catalog;
 use Magento\ConfigurableProduct as ConfigurableProduct;
+use Magento\GroupedProduct as GroupedProduct;
 use Magento\Store as Store;
 
 class SendOrderDetails implements Framework\Event\ObserverInterface
@@ -16,19 +17,22 @@ class SendOrderDetails implements Framework\Event\ObserverInterface
     private $productModel;
     private $imageHelper;
     private $configProductModel;
+    private $groupedProductModel;
 
     public function __construct(
         Reviews\Helper\Config $config,
         Reviews\Model\Api $api,
         Catalog\Model\ProductFactory $product,
         Catalog\Helper\Image $image,
-        ConfigurableProduct\Model\ResourceModel\Product\Type\Configurable $configurable
+        ConfigurableProduct\Model\ResourceModel\Product\Type\Configurable $configurable,
+        GroupedProduct\Model\Product\Type\Grouped $grouped
     ) {
         $this->configHelper = $config;
         $this->apiModel = $api;
         $this->productModel = $product;
         $this->imageHelper = $image;
         $this->configProductModel = $configurable;
+        $this->groupedProductModel = $grouped;
     }
 
     public function execute(Framework\Event\Observer $observer)
@@ -77,15 +81,24 @@ class SendOrderDetails implements Framework\Event\ObserverInterface
                 foreach ($items as $item) {
 
                     if ($this->configHelper->isUsingGroupSkus($magento_store_id)) {
-                        // If product is part of a configurable product, use the configurable product details.
-                        if ($item->getProduct()->getTypeId() == 'simple' || $item->getProduct()->getTypeId() == \Magento\ConfigurableProduct\Model\Product\Type\Configurable::TYPE_CODE) {
-                            $productId = $item->getProduct()->getId();
-                            $model = $this->productModel->create();
-                            $item = $model->load($productId);
+                        // If product is a variant of a grouped/configurable parent, send the
+                        // parent details so all variant reviews aggregate onto the parent SKU
+                        // (the on-site widget queries the parent SKU). Mirrors Feed.php:
+                        // resolve grouped parents first, then configurable.
+                        $productId = $item->getProduct()->getId();
+                        $groupedParentIds = $this->groupedProductModel->getParentIdsByChild($productId);
+                        $configurableParentIds = $this->configProductModel->getParentIdsByChild($productId);
+                        if (!empty($groupedParentIds)) {
+                            $productId = $groupedParentIds[0];
+                        } elseif (!empty($configurableParentIds)) {
+                            $productId = $configurableParentIds[0];
                         }
+                        $item = $this->productModel->create()->load($productId);
                     }
                     $imageUrl = $this->imageHelper->init($item, 'product_page_image_large')->getUrl();
-                    $p[] = [
+                    // Key by SKU so multiple children of the same parent collapse to a single
+                    // invitation entry once their SKUs are rolled up to the parent.
+                    $p[$item->getSku()] = [
                         'image' => $imageUrl,
                         'id' => $item->getId(),
                         'sku' => $item->getSku(),
@@ -93,6 +106,7 @@ class SendOrderDetails implements Framework\Event\ObserverInterface
                         'pageUrl' => $item->getProductUrl()
                     ];
                 }
+                $p = array_values($p);
 
                 $name = $order->getCustomerName();
 

--- a/Observer/SendOrderDetails.php
+++ b/Observer/SendOrderDetails.php
@@ -87,11 +87,13 @@ class SendOrderDetails implements Framework\Event\ObserverInterface
                         // resolve grouped parents first, then configurable.
                         $productId = $item->getProduct()->getId();
                         $groupedParentIds = $this->groupedProductModel->getParentIdsByChild($productId);
-                        $configurableParentIds = $this->configProductModel->getParentIdsByChild($productId);
                         if (!empty($groupedParentIds)) {
                             $productId = $groupedParentIds[0];
-                        } elseif (!empty($configurableParentIds)) {
-                            $productId = $configurableParentIds[0];
+                        } else {
+                            $configurableParentIds = $this->configProductModel->getParentIdsByChild($productId);
+                            if (!empty($configurableParentIds)) {
+                                $productId = $configurableParentIds[0];
+                            }
                         }
                         $item = $this->productModel->create()->load($productId);
                     }

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ You'll need to sign up at [Reviews.co.uk](https://www.reviews.co.uk "Reviews.co.
 
 | Magento Version | Php Version | REVIEWS.io Plugin Version  |
 |-----------------|-------------|----------------------------|
-| >= 2.4.6        | 8.1, 8.2    | reviewscouk/reviews:0.0.72 |
-| >= 2.4.4        | 8.1         | reviewscouk/reviews:0.0.72 |
-| <= 2.4.3        | <= 7.4      | reviewscouk/reviews:0.0.72 |
+| >= 2.4.6        | 8.1, 8.2    | reviewscouk/reviews:0.0.73 |
+| >= 2.4.4        | 8.1         | reviewscouk/reviews:0.0.73 |
+| <= 2.4.3        | <= 7.4      | reviewscouk/reviews:0.0.73 |
 
 # Installation
 
@@ -18,7 +18,7 @@ You'll need to sign up at [Reviews.co.uk](https://www.reviews.co.uk "Reviews.co.
 2. As this plugin is hosted on [packagist.org](http://packagist.org), you simply use the following to instruct composer to fetch and install the module:
 
     ```bash
-    composer require reviewscouk/reviews:0.0.72
+    composer require reviewscouk/reviews:0.0.73
     ```
 
 3. When this is complete, `cd` to `/bin` and run the following:


### PR DESCRIPTION
Jira ticket: https://clearerio.atlassian.net/browse/REVIEWS-4263

The REVIEWS.io Magento plugin has a "Use Group SKUs" option. When it is enabled, a review invitation for a child variant of a configurable product should be sent against the parent SKU, not the child SKU. This lets all variant reviews aggregate onto the parent product so the on-site widget (which queries the parent SKU) can find and display them.

Today the plugin does the opposite: for a child variant it re-loads the same simple (child) product and sends the child SKU in the invitation. The resulting review lands on the child SKU. So there is no match and the review does not show. The issue affects all products that have child variants.