### PR TITLE
[REVIEWS-4432] Fix Magento upgrade error

### DIFF
--- a/Block/Product/CustomRatingSnippet.php
+++ b/Block/Product/CustomRatingSnippet.php
@@ -13,8 +13,12 @@ class CustomRatingSnippet extends \Reviewscouk\Reviews\Block\Product\RatingSnipp
      */
     public function getTemplate()
     {
-        $isEnabled = $this->_scopeConfig->isSetFlag('reviewscouk_reviews_onpage/widget/category_rating_snippet_widget_enabled');
-   
+        // Outer gate on the same feature getRatingSnippet() guards, so it has to
+        // read the same scope: go through the helper (which owns the config path)
+        // and the store resolution inherited from RatingSnippet, instead of a
+        // bare isSetFlag() that only ever sees default/global scope.
+        $isEnabled = $this->reviewsConfig->isCategoryRatingSnippetWidgetEnabled($this->getCurrentStoreId());
+
         if ($isEnabled) {
             return 'Reviewscouk_Reviews::category/list.phtml';
         }

--- a/Block/Product/RatingSnippet.php
+++ b/Block/Product/RatingSnippet.php
@@ -39,10 +39,10 @@ class RatingSnippet extends ListProduct
         \Magento\Catalog\Api\CategoryRepositoryInterface $categoryRepository,
         \Magento\Framework\Url\Helper\Data $urlHelper,
         array $data = [],
-        \Magento\Customer\Model\Session $customerSession = null,
-        \Magento\Catalog\Model\CategoryFactory $categoryFactory = null,
-        ReviewsConfig $reviewsConfigHelper = null,
-        StoreManagerInterface $storeManager = null
+        ?\Magento\Customer\Model\Session $customerSession = null,
+        ?\Magento\Catalog\Model\CategoryFactory $categoryFactory = null,
+        ?ReviewsConfig $reviewsConfigHelper = null,
+        ?StoreManagerInterface $storeManager = null
     ) {
         $this->_customerSession = $customerSession;
         $this->categoryFactory = $categoryFactory;

--- a/Block/Product/RatingSnippet.php
+++ b/Block/Product/RatingSnippet.php
@@ -19,10 +19,6 @@ class RatingSnippet extends ListProduct
     //protected $reviewsConfig = Reviews\Helper\Config;
     // protected $_storeManager = StoreManagerInterface::class;
     /**
-     * Store manager, not a store. Resolved to a concrete store view lazily in
-     * getCurrentStoreId() — see REVIEWS-4382 for why this is not done in the
-     * constructor.
-     *
      * @var StoreManagerInterface|null
      */
     protected $store;
@@ -95,11 +91,6 @@ class RatingSnippet extends ListProduct
      * Prefers the explicitly injected store manager (kept for backward
      * compatibility with direct instantiation) and falls back to the one
      * AbstractBlock receives via $context, which DI always populates.
-     *
-     * Resolution is deliberately lazy rather than done in the constructor,
-     * matching the pattern REVIEWS-4382 established in Model/Api.php: on
-     * headless/multi-store installs getStore() can throw at construction time.
-     *
      * Protected so CustomRatingSnippet can gate its template swap on the same
      * scope, rather than growing a second scope-resolution path.
      *

--- a/Block/Product/RatingSnippet.php
+++ b/Block/Product/RatingSnippet.php
@@ -18,6 +18,13 @@ class RatingSnippet extends ListProduct
     protected $categoryFactory;
     //protected $reviewsConfig = Reviews\Helper\Config;
     // protected $_storeManager = StoreManagerInterface::class;
+    /**
+     * Store manager, not a store. Resolved to a concrete store view lazily in
+     * getCurrentStoreId() — see REVIEWS-4382 for why this is not done in the
+     * constructor.
+     *
+     * @var StoreManagerInterface|null
+     */
     protected $store;
     protected $reviewsConfig;
     /**
@@ -82,10 +89,39 @@ class RatingSnippet extends ListProduct
         return $productSkus;
     }
 
+    /**
+     * Resolve the current store view id for config scope lookups.
+     *
+     * Prefers the explicitly injected store manager (kept for backward
+     * compatibility with direct instantiation) and falls back to the one
+     * AbstractBlock receives via $context, which DI always populates.
+     *
+     * Resolution is deliberately lazy rather than done in the constructor,
+     * matching the pattern REVIEWS-4382 established in Model/Api.php: on
+     * headless/multi-store installs getStore() can throw at construction time.
+     *
+     * @return int|string|null Store id, or null to fall back to default scope.
+     */
+    private function getCurrentStoreId()
+    {
+        $storeManager = $this->store ?: $this->_storeManager;
+        if (!$storeManager) {
+            return null;
+        }
+
+        try {
+            return $storeManager->getStore()->getId();
+        } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
+            // A category page must not fatal because scope resolution failed;
+            // fall back to default scope, which is the pre-fix behaviour.
+            return null;
+        }
+    }
+
     public function getRatingSnippet($product)
     {
         $escaper = new Escaper();
-        $ratingSnippetEnabled = $this->reviewsConfig->isCategoryRatingSnippetWidgetEnabled($this->store);
+        $ratingSnippetEnabled = $this->reviewsConfig->isCategoryRatingSnippetWidgetEnabled($this->getCurrentStoreId());
         $skus = $this->getProductSkus($product);
         $html = '';
         if($ratingSnippetEnabled) {

--- a/Block/Product/RatingSnippet.php
+++ b/Block/Product/RatingSnippet.php
@@ -100,9 +100,12 @@ class RatingSnippet extends ListProduct
      * matching the pattern REVIEWS-4382 established in Model/Api.php: on
      * headless/multi-store installs getStore() can throw at construction time.
      *
+     * Protected so CustomRatingSnippet can gate its template swap on the same
+     * scope, rather than growing a second scope-resolution path.
+     *
      * @return int|string|null Store id, or null to fall back to default scope.
      */
-    private function getCurrentStoreId()
+    protected function getCurrentStoreId()
     {
         $storeManager = $this->store ?: $this->_storeManager;
         if (!$storeManager) {

--- a/Block/Product/Reviewwidget.php
+++ b/Block/Product/Reviewwidget.php
@@ -133,7 +133,10 @@ class Reviewwidget extends Framework\View\Element\Template
 
     protected function getWidgetColor()
     {
-        $colour = $this->configHelper->getProductWidgetColour($this->store->getId());
+        // Config value is null when unset; coalesce so strpos()/preg_match() below
+        // always receive a string (passing null is deprecated on PHP 8.1+, and
+        // Magento's ErrorHandler turns that deprecation into a storefront 500).
+        $colour = $this->configHelper->getProductWidgetColour($this->store->getId()) ?? '';
         // people will sometimes put hash and sometimes they will forgot so we need to check for this error
         if (isset($colour) && strpos($colour, '#') === false) {
             $colour = '#' . $colour;

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ You'll need to sign up at [Reviews.co.uk](https://www.reviews.co.uk "Reviews.co.
 
 | Magento Version | Php Version | REVIEWS.io Plugin Version  |
 |-----------------|-------------|----------------------------|
-| >= 2.4.7        | 8.3, 8.4, 8.5 | reviewscouk/reviews:0.0.75 |
+| >= 2.4.7        | >= 8.3 | reviewscouk/reviews:0.0.75 |
 | >= 2.4.6        | 8.1, 8.2    | reviewscouk/reviews:0.0.74 |
 | >= 2.4.4        | 8.1         | reviewscouk/reviews:0.0.74 |
 | <= 2.4.3        | <= 7.4      | reviewscouk/reviews:0.0.74 |
@@ -19,7 +19,7 @@ You'll need to sign up at [Reviews.co.uk](https://www.reviews.co.uk "Reviews.co.
 2. As this plugin is hosted on [packagist.org](http://packagist.org), you simply use the following to instruct composer to fetch and install the module:
 
     ```bash
-    composer require reviewscouk/reviews:0.0.74
+    composer require reviewscouk/reviews:0.0.75
     ```
 
 3. When this is complete, `cd` to `/bin` and run the following:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ You'll need to sign up at [Reviews.co.uk](https://www.reviews.co.uk "Reviews.co.
 
 | Magento Version | Php Version | REVIEWS.io Plugin Version  |
 |-----------------|-------------|----------------------------|
+| >= 2.4.7        | 8.3, 8.4, 8.5 | reviewscouk/reviews:0.0.75 |
 | >= 2.4.6        | 8.1, 8.2    | reviewscouk/reviews:0.0.74 |
 | >= 2.4.4        | 8.1         | reviewscouk/reviews:0.0.74 |
 | <= 2.4.3        | <= 7.4      | reviewscouk/reviews:0.0.74 |


### PR DESCRIPTION
Ticket URL: https://clearerio.atlassian.net/browse/REVIEWS-4432

A merchant upgraded their store to Magento 2.4.9 on PHP 8.5 and can no longer run `bin/magento setup:di:compile`. Compilation aborts ~11% in with:

```
In ErrorHandler.php line 61:
  Deprecated Functionality: Reviewscouk\Reviews\Block\Product\RatingSnippet::__construct():
  Implicitly marking parameter $customerSession as nullable is deprecated,
  the explicit nullable type must be used instead
  in /var/www/html/ixl/vendor/reviewscouk/reviews/Block/Product/RatingSnippet.php on line 42
```